### PR TITLE
From global to vendor includes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,16 +11,19 @@
         }
     ],
     "autoload": {
-        "exclude-from-files": [
-            "src/phink/web/ui/widget/pager/pager.class.php",            
-            "src/phink/web/ui/widget/console/consolew.class.php"
-        ],
         "classmap": [
             "src/phink/"
+        ],
+        "exclude-from-classmap":
+        [
+            "src/phink/phink_library.php",            
+            "src/phink/web/ui/widget/pager/pager.class.php",            
+            "src/phink/web/ui/widget/console/consolew.class.php"
         ]
     },    
     "require": {
         "php": ">=7.0.0",
+	"twig/twig": "^2.0",
         "mcaskill/composer-exclude-files": "^1.1.0",
         "components/jquery": ">=1.9.1",
         "components/jqueryui": ">=1.12.1",

--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,27 @@
         }
     ],
     "autoload": {
+        "exclude-from-files": [
+            "src/phink/web/ui/widget/pager/pager.class.php",            
+            "src/phink/web/ui/widget/console/consolew.class.php"
+        ],
         "classmap": [
             "src/phink/"
         ]
     },    
     "require": {
         "php": ">=7.0.0",
+        "mcaskill/composer-exclude-files": "^1.1.0",
+        "components/jquery": ">=1.9.1",
+        "components/jqueryui": ">=1.12.1",
+        "components/font-awesome": "=4.7.0",
+        "components/bootstrap": "=3.3.5",
+        "components/bootstrap-default": "=3.3.5"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "4.3.*",
+        "php-coveralls/php-coveralls": "^1.0",
+        "squizlabs/php_codesniffer": "^3.2",
         "components/jquery": ">=1.9.1",
         "components/jqueryui": ">=1.12.1",
         "components/font-awesome": "=4.7.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "d0f06583679f42958b3e3df5c6e21cb8",
+    "content-hash": "b3862eb3b0cc8a79d62ce0ce53ef5635",
     "packages": [
         {
             "name": "components/bootstrap",
@@ -336,6 +336,190 @@
             ],
             "description": "Exclude files from autoload_files.php",
             "time": "2018-12-18T18:58:13+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "82ebae02209c21113908c229e9883c419720738a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/82ebae02209c21113908c229e9883c419720738a",
+                "reference": "82ebae02209c21113908c229e9883c419720738a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.11-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                },
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2019-02-06T07:57:58+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "fe5e94c604826c35a32fa832f35bd036b6799609"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/fe5e94c604826c35a32fa832f35bd036b6799609",
+                "reference": "fe5e94c604826c35a32fa832f35bd036b6799609",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.11-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2019-02-06T07:57:58+00:00"
+        },
+        {
+            "name": "twig/twig",
+            "version": "v2.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/twigphp/Twig.git",
+                "reference": "5240e21982885b76629552d83b4ebb6d41ccde6b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/5240e21982885b76629552d83b4ebb6d41ccde6b",
+                "reference": "5240e21982885b76629552d83b4ebb6d41ccde6b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-mbstring": "^1.3"
+            },
+            "require-dev": {
+                "psr/container": "^1.0",
+                "symfony/debug": "^2.7",
+                "symfony/phpunit-bridge": "^3.4.19|^4.1.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.10-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Twig_": "lib/"
+                },
+                "psr-4": {
+                    "Twig\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Armin Ronacher",
+                    "email": "armin.ronacher@active-4.com",
+                    "role": "Project Founder"
+                },
+                {
+                    "name": "Twig Team",
+                    "homepage": "https://twig.symfony.com/contributors",
+                    "role": "Contributors"
+                }
+            ],
+            "description": "Twig, the flexible, fast, and secure template language for PHP",
+            "homepage": "https://twig.symfony.com",
+            "keywords": [
+                "templating"
+            ],
+            "time": "2019-05-14T12:03:52+00:00"
         }
     ],
     "packages-dev": [
@@ -1663,123 +1847,6 @@
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
             "time": "2019-02-07T11:40:08+00:00"
-        },
-        {
-            "name": "symfony/polyfill-ctype",
-            "version": "v1.11.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "82ebae02209c21113908c229e9883c419720738a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/82ebae02209c21113908c229e9883c419720738a",
-                "reference": "82ebae02209c21113908c229e9883c419720738a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "suggest": {
-                "ext-ctype": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.11-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                },
-                {
-                    "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
-                }
-            ],
-            "description": "Symfony polyfill for ctype functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "ctype",
-                "polyfill",
-                "portable"
-            ],
-            "time": "2019-02-06T07:57:58+00:00"
-        },
-        {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.11.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "fe5e94c604826c35a32fa832f35bd036b6799609"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/fe5e94c604826c35a32fa832f35bd036b6799609",
-                "reference": "fe5e94c604826c35a32fa832f35bd036b6799609",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "suggest": {
-                "ext-mbstring": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.11-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for the Mbstring extension",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "mbstring",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "time": "2019-02-06T07:57:58+00:00"
         },
         {
             "name": "symfony/stopwatch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "f33e8bec45074d7f72d323825b691095",
+    "content-hash": "d0f06583679f42958b3e3df5c6e21cb8",
     "packages": [
         {
             "name": "components/bootstrap",
@@ -288,9 +288,1600 @@
             ],
             "description": "jQuery UI is a curated set of user interface interactions, effects, widgets, and themes built on top of the jQuery JavaScript Library. Whether you're building highly interactive web applications or you just need to add a date picker to a form control, jQuery UI is the perfect choice.",
             "time": "2016-09-16T05:47:55+00:00"
+        },
+        {
+            "name": "mcaskill/composer-exclude-files",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mcaskill/composer-plugin-exclude-files.git",
+                "reference": "81fdd0def4d3aa9c26715f1108706ae92ab0a98c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mcaskill/composer-plugin-exclude-files/zipball/81fdd0def4d3aa9c26715f1108706ae92ab0a98c",
+                "reference": "81fdd0def4d3aa9c26715f1108706ae92ab0a98c",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0"
+            },
+            "require-dev": {
+                "composer/composer": "^1.0",
+                "php-coveralls/php-coveralls": "^2.0",
+                "phpunit/phpunit": "^5.7 || ^6.5",
+                "squizlabs/php_codesniffer": "^3.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                },
+                "class": "McAskill\\Composer\\ExcludeFilePlugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "McAskill\\Composer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Chauncey McAskill",
+                    "email": "chauncey@mcaskill.ca"
+                }
+            ],
+            "description": "Exclude files from autoload_files.php",
+            "time": "2018-12-18T18:58:13+00:00"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "a2c590166b2133a4633738648b6b064edae0814a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/a2c590166b2133a4633738648b6b064edae0814a",
+                "reference": "a2c590166b2133a4633738648b6b064edae0814a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^6.0",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^0.13",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpstan/phpstan-shim": "^0.11",
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.com/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "time": "2019-03-17T17:37:11+00:00"
+        },
+        {
+            "name": "guzzle/guzzle",
+            "version": "v3.9.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle3.git",
+                "reference": "0645b70d953bc1c067bbc8d5bc53194706b628d9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle3/zipball/0645b70d953bc1c067bbc8d5bc53194706b628d9",
+                "reference": "0645b70d953bc1c067bbc8d5bc53194706b628d9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "php": ">=5.3.3",
+                "symfony/event-dispatcher": "~2.1"
+            },
+            "replace": {
+                "guzzle/batch": "self.version",
+                "guzzle/cache": "self.version",
+                "guzzle/common": "self.version",
+                "guzzle/http": "self.version",
+                "guzzle/inflection": "self.version",
+                "guzzle/iterator": "self.version",
+                "guzzle/log": "self.version",
+                "guzzle/parser": "self.version",
+                "guzzle/plugin": "self.version",
+                "guzzle/plugin-async": "self.version",
+                "guzzle/plugin-backoff": "self.version",
+                "guzzle/plugin-cache": "self.version",
+                "guzzle/plugin-cookie": "self.version",
+                "guzzle/plugin-curlauth": "self.version",
+                "guzzle/plugin-error-response": "self.version",
+                "guzzle/plugin-history": "self.version",
+                "guzzle/plugin-log": "self.version",
+                "guzzle/plugin-md5": "self.version",
+                "guzzle/plugin-mock": "self.version",
+                "guzzle/plugin-oauth": "self.version",
+                "guzzle/service": "self.version",
+                "guzzle/stream": "self.version"
+            },
+            "require-dev": {
+                "doctrine/cache": "~1.3",
+                "monolog/monolog": "~1.0",
+                "phpunit/phpunit": "3.7.*",
+                "psr/log": "~1.0",
+                "symfony/class-loader": "~2.1",
+                "zendframework/zend-cache": "2.*,<2.3",
+                "zendframework/zend-log": "2.*,<2.3"
+            },
+            "suggest": {
+                "guzzlehttp/guzzle": "Guzzle 5 has moved to a new package name. The package you have installed, Guzzle 3, is deprecated."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Guzzle": "src/",
+                    "Guzzle\\Tests": "tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Guzzle Community",
+                    "homepage": "https://github.com/guzzle/guzzle/contributors"
+                }
+            ],
+            "description": "PHP HTTP client. This library is deprecated in favor of https://packagist.org/packages/guzzlehttp/guzzle",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "abandoned": "guzzlehttp/guzzle",
+            "time": "2015-03-18T18:23:50+00:00"
+        },
+        {
+            "name": "php-coveralls/php-coveralls",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-coveralls/php-coveralls.git",
+                "reference": "37f8f83fe22224eb9d9c6d593cdeb33eedd2a9ad"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-coveralls/php-coveralls/zipball/37f8f83fe22224eb9d9c6d593cdeb33eedd2a9ad",
+                "reference": "37f8f83fe22224eb9d9c6d593cdeb33eedd2a9ad",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-simplexml": "*",
+                "guzzle/guzzle": "^2.8 || ^3.0",
+                "php": "^5.3.3 || ^7.0",
+                "psr/log": "^1.0",
+                "symfony/config": "^2.1 || ^3.0 || ^4.0",
+                "symfony/console": "^2.1 || ^3.0 || ^4.0",
+                "symfony/stopwatch": "^2.0 || ^3.0 || ^4.0",
+                "symfony/yaml": "^2.0 || ^3.0 || ^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.4.3 || ^6.0"
+            },
+            "suggest": {
+                "symfony/http-kernel": "Allows Symfony integration"
+            },
+            "bin": [
+                "bin/coveralls"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Satooshi\\": "src/Satooshi/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kitamura Satoshi",
+                    "email": "with.no.parachute@gmail.com",
+                    "homepage": "https://www.facebook.com/satooshi.jp"
+                }
+            ],
+            "description": "PHP client library for Coveralls API",
+            "homepage": "https://github.com/php-coveralls/php-coveralls",
+            "keywords": [
+                "ci",
+                "coverage",
+                "github",
+                "test"
+            ],
+            "time": "2017-12-06T23:17:56+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "2.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/eabf68b476ac7d0f73793aada060f1c1a9bf8979",
+                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "phpunit/php-file-iterator": "~1.3",
+                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-token-stream": "~1.3",
+                "sebastian/environment": "^1.3.2",
+                "sebastian/version": "~1.0"
+            },
+            "require-dev": {
+                "ext-xdebug": ">=2.1.4",
+                "phpunit/phpunit": "~4"
+            },
+            "suggest": {
+                "ext-dom": "*",
+                "ext-xdebug": ">=2.2.1",
+                "ext-xmlwriter": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "time": "2015-10-06T15:47:00+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "1.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "acd690379117b042d1c8af1fafd61bde001bf6bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/acd690379117b042d1c8af1fafd61bde001bf6bb",
+                "reference": "acd690379117b042d1c8af1fafd61bde001bf6bb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "File/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "time": "2013-10-10T15:34:57+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "time": "2015-06-21T13:50:34+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "1.0.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "time": "2017-02-26T11:10:40+00:00"
+        },
+        {
+            "name": "phpunit/php-token-stream",
+            "version": "1.4.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/1ce90ba27c42e4e44e6d8458241466380b51fa16",
+                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Wrapper around PHP's tokenizer extension.",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+            "keywords": [
+                "tokenizer"
+            ],
+            "time": "2017-12-04T08:55:13+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "4.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "2dab9d593997db4abcf58d0daf798eb4e9cecfe1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/2dab9d593997db4abcf58d0daf798eb4e9cecfe1",
+                "reference": "2dab9d593997db4abcf58d0daf798eb4e9cecfe1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-spl": "*",
+                "php": ">=5.3.3",
+                "phpunit/php-code-coverage": "~2.0",
+                "phpunit/php-file-iterator": "~1.3.2",
+                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-timer": "~1.0.2",
+                "phpunit/phpunit-mock-objects": "~2.3",
+                "sebastian/comparator": "~1.0",
+                "sebastian/diff": "~1.1",
+                "sebastian/environment": "~1.0",
+                "sebastian/exporter": "~1.0",
+                "sebastian/version": "~1.0",
+                "symfony/yaml": "~2.0"
+            },
+            "suggest": {
+                "phpunit/php-invoker": "~1.1"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "",
+                "../../symfony/yaml/"
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "http://www.phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "time": "2014-11-11T10:11:09+00:00"
+        },
+        {
+            "name": "phpunit/phpunit-mock-objects",
+            "version": "2.3.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
+                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/ac8e7a3db35738d56ee9a76e78a4e03d97628983",
+                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": ">=5.3.3",
+                "phpunit/php-text-template": "~1.2",
+                "sebastian/exporter": "~1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "suggest": {
+                "ext-soap": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Mock Object library for PHPUnit",
+            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
+            "keywords": [
+                "mock",
+                "xunit"
+            ],
+            "abandoned": true,
+            "time": "2015-10-02T06:51:40+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
+                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2018-11-20T15:27:04+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "1.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
+                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "sebastian/diff": "~1.2",
+                "sebastian/exporter": "~1.2 || ~2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "time": "2017-01-29T09:50:25+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "1.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff"
+            ],
+            "time": "2017-05-22T07:24:03+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "1.3.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8 || ^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "time": "2016-08-18T05:49:44+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "sebastian/recursion-context": "~1.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "time": "2016-06-17T09:04:28+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
+                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "time": "2016-10-03T07:41:43+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "1.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "time": "2015-06-21T13:59:46+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
+                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2019-04-10T23:49:02+00:00"
+        },
+        {
+            "name": "symfony/config",
+            "version": "v4.2.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/config.git",
+                "reference": "0e745ead307d5dcd4e163e94a47ec04b1428943f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/config/zipball/0e745ead307d5dcd4e163e94a47ec04b1428943f",
+                "reference": "0e745ead307d5dcd4e163e94a47ec04b1428943f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/filesystem": "~3.4|~4.0",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "conflict": {
+                "symfony/finder": "<3.4"
+            },
+            "require-dev": {
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/event-dispatcher": "~3.4|~4.0",
+                "symfony/finder": "~3.4|~4.0",
+                "symfony/yaml": "~3.4|~4.0"
+            },
+            "suggest": {
+                "symfony/yaml": "To use the yaml reference dumper"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Config\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Config Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-04-01T14:03:25+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v4.2.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "e2840bb38bddad7a0feaf85931e38fdcffdb2f81"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/e2840bb38bddad7a0feaf85931e38fdcffdb2f81",
+                "reference": "e2840bb38bddad7a0feaf85931e38fdcffdb2f81",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/contracts": "^1.0",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.4",
+                "symfony/process": "<3.3"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~3.4|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/event-dispatcher": "~3.4|~4.0",
+                "symfony/lock": "~3.4|~4.0",
+                "symfony/process": "~3.4|~4.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/lock": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-04-08T14:23:48+00:00"
+        },
+        {
+            "name": "symfony/contracts",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/contracts.git",
+                "reference": "d3636025e8253c6144358ec0a62773cae588395b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/contracts/zipball/d3636025e8253c6144358ec0a62773cae588395b",
+                "reference": "d3636025e8253c6144358ec0a62773cae588395b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "require-dev": {
+                "psr/cache": "^1.0",
+                "psr/container": "^1.0",
+                "symfony/polyfill-intl-idn": "^1.10"
+            },
+            "suggest": {
+                "psr/cache": "When using the Cache contracts",
+                "psr/container": "When using the Service contracts",
+                "symfony/cache-contracts-implementation": "",
+                "symfony/event-dispatcher-implementation": "",
+                "symfony/http-client-contracts-implementation": "",
+                "symfony/service-contracts-implementation": "",
+                "symfony/translation-contracts-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\": ""
+                },
+                "exclude-from-classmap": [
+                    "**/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A set of abstractions extracted out of the Symfony components",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-04-27T14:29:50+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v2.8.50",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "a77e974a5fecb4398833b0709210e3d5e334ffb0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/a77e974a5fecb4398833b0709210e3d5e334ffb0",
+                "reference": "a77e974a5fecb4398833b0709210e3d5e334ffb0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "^2.0.5|~3.0.0",
+                "symfony/dependency-injection": "~2.6|~3.0.0",
+                "symfony/expression-language": "~2.6|~3.0.0",
+                "symfony/stopwatch": "~2.3|~3.0.0"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "",
+                "symfony/http-kernel": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony EventDispatcher Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-11-21T14:20:20+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v4.2.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "e16b9e471703b2c60b95f14d31c1239f68f11601"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/e16b9e471703b2c60b95f14d31c1239f68f11601",
+                "reference": "e16b9e471703b2c60b95f14d31c1239f68f11601",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Filesystem Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-02-07T11:40:08+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "82ebae02209c21113908c229e9883c419720738a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/82ebae02209c21113908c229e9883c419720738a",
+                "reference": "82ebae02209c21113908c229e9883c419720738a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.11-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                },
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2019-02-06T07:57:58+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "fe5e94c604826c35a32fa832f35bd036b6799609"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/fe5e94c604826c35a32fa832f35bd036b6799609",
+                "reference": "fe5e94c604826c35a32fa832f35bd036b6799609",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.11-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2019-02-06T07:57:58+00:00"
+        },
+        {
+            "name": "symfony/stopwatch",
+            "version": "v4.2.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/stopwatch.git",
+                "reference": "b1a5f646d56a3290230dbc8edf2a0d62cda23f67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/b1a5f646d56a3290230dbc8edf2a0d62cda23f67",
+                "reference": "b1a5f646d56a3290230dbc8edf2a0d62cda23f67",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/contracts": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Stopwatch\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Stopwatch Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-01-16T20:31:39+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v2.8.50",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "02c1859112aa779d9ab394ae4f3381911d84052b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/02c1859112aa779d9ab394ae4f3381911d84052b",
+                "reference": "02c1859112aa779d9ab394ae4f3381911d84052b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-11-11T11:18:13+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],

--- a/src/phink/autoloader.php
+++ b/src/phink/autoloader.php
@@ -32,9 +32,9 @@ class TAutoloader extends TStaticObject
      */
     public function __construct($baseDirectory = __DIR__)
     {
-        $this->directory = $baseDirectory;
-        $this->prefix = __NAMESPACE__ . '\\';
-        $this->prefixLength = strlen($this->prefix);
+        // $this->directory = $baseDirectory;
+        // $this->prefix = __NAMESPACE__ . '\\';
+        // $this->prefixLength = strlen($this->prefix);
     }
 
     /**
@@ -44,7 +44,7 @@ class TAutoloader extends TStaticObject
      */
     public static function register($prepend = false)
     {
-        spl_autoload_register(array(new self, 'autoload'), true, $prepend);
+        // spl_autoload_register(array(new self, 'autoload'), true, $prepend);
     }
 
     public static function classNameToFilename($className)
@@ -109,18 +109,18 @@ class TAutoloader extends TStaticObject
      */
     public function autoload($className)
     {
-        if (0 === strpos($className, $this->prefix)) {
-            $parts = explode('\\', substr($className, $this->prefixLength));
-            $className = array_pop($parts);
+        // if (0 === strpos($className, $this->prefix)) {
+        //     $parts = explode('\\', substr($className, $this->prefixLength));
+        //     $className = array_pop($parts);
             
-            $translated = self::classNameToFilename($className);
+        //     $translated = self::classNameToFilename($className);
             
-            $filepath = $this->directory . DIRECTORY_SEPARATOR . strtolower(implode(DIRECTORY_SEPARATOR, $parts) . DIRECTORY_SEPARATOR . $translated);
-            $filepath .= (file_exists($filepath . PREHTML_EXTENSION)) ? CLASS_EXTENSION : '.php';
+        //     $filepath = $this->directory . DIRECTORY_SEPARATOR . strtolower(implode(DIRECTORY_SEPARATOR, $parts) . DIRECTORY_SEPARATOR . $translated);
+        //     $filepath .= (file_exists($filepath . PREHTML_EXTENSION)) ? CLASS_EXTENSION : '.php';
             
-            //file_put_contents(STARTER_FILE, "include '$filepath';"  . "\n", FILE_APPEND);
-            include $filepath;
-        }
+        //     //file_put_contents(STARTER_FILE, "include '$filepath';"  . "\n", FILE_APPEND);
+        //     include $filepath;
+        // }
     }
     
     private static function _includeInnerClass($viewName, $info, $withCode = true)
@@ -152,12 +152,12 @@ class TAutoloader extends TStaticObject
      */
     public static function includeClass($filename, $params = 0)
     {
-        if (!file_exists(SITE_ROOT . $filename)) {
+        if (!file_exists(SRC_ROOT . $filename)) {
             //self::getLogger()->debug('INCLUDE CLASS : FILE ' . $filename . ' DOES NOT EXIST');
             return false;
         }
         
-        $classText = file_get_contents(SITE_ROOT . $filename, FILE_USE_INCLUDE_PATH);
+        $classText = file_get_contents(SRC_ROOT . $filename, FILE_USE_INCLUDE_PATH);
         
         $code = $classText;
         
@@ -198,7 +198,7 @@ class TAutoloader extends TStaticObject
             if (\Phar::running() != '') {
                 include pathinfo($filename, PATHINFO_BASENAME);
             } else {
-                // include SITE_ROOT . $filename;
+                // include SRC_ROOT . $filename;
             }
         }
         
@@ -299,30 +299,30 @@ class TAutoloader extends TStaticObject
         if ($info !== null) {
             //$classFilename = ROOT_PATH . $info->path . \Phink\TAutoloader::classNameToFilename($viewName) . CLASS_EXTENSION;
             /* $cacheFilename = REL_RUNTIME_DIR . str_replace(DIRECTORY_SEPARATOR, '_', ROOT_PATH . $info->path . \Phink\TAutoloader::classNameToFilename($viewName)) . CLASS_EXTENSION; */
-            if($info->path[0] == '@') {
-                $path = str_replace("@" . DIRECTORY_SEPARATOR, PHINK_ROOT, $info->path);
+            if ($info->path[0] == '@') {
+                $path = str_replace("@" . DIRECTORY_SEPARATOR, PHINK_VENDOR, $info->path);
             } else {
-                $path = PHINK_ROOT . $info->path; 
+                $path = PHINK_VENDOR . $info->path;
             }
             // $cacheFilename = REL_RUNTIME_DIR . str_replace(DIRECTORY_SEPARATOR, '_', $path . $ctrl->getId()) . CLASS_EXTENSION;
             $cacheFilename = REL_RUNTIME_DIR . str_replace(DIRECTORY_SEPARATOR, '_', $path . \Phink\TAutoloader::classNameToFilename($viewName)) . CLASS_EXTENSION;
-
         } else {
             //$classFilename = 'app' . DIRECTORY_SEPARATOR . 'controllers' . DIRECTORY_SEPARATOR . $viewName . CLASS_EXTENSION;
             $cacheFilename = \Phink\TAutoloader::cacheFilenameFromView($viewName);
-            $cacheJsFilename = \Phink\TAutoloader::cacheJsFilenameFromView($viewName);
             self::getLogger()->debug('CACHED JS FILENAME: ' . $cacheJsFilename, __FILE__, __LINE__);
         }
+        $cacheJsFilename = \Phink\TAutoloader::cacheJsFilenameFromView($viewName);
+        $cacheCssFilename = \Phink\TAutoloader::cacheCssFilenameFromView($viewName);
         
-        if (file_exists(SITE_ROOT . $cacheFilename)) {
+        if (file_exists(SRC_ROOT . $cacheFilename)) {
             if (file_exists(DOCUMENT_ROOT . $cacheJsFilename)) {
                 self::getLogger()->debug('INCLUDE CACHED JS CONTROL: ' . DOCUMENT_ROOT . $cacheJsFilename, __FILE__, __LINE__);
                 $ctrl->getResponse()->addScript($cacheJsFilename);
             }
-            self::getLogger()->debug('INCLUDE CACHED CONTROL: ' . SITE_ROOT . $cacheFilename, __FILE__, __LINE__);
+            self::getLogger()->debug('INCLUDE CACHED CONTROL: ' . SRC_ROOT . $cacheFilename, __FILE__, __LINE__);
             self::includeClass($cacheFilename, RETURN_CODE);
 
-            include SITE_ROOT . $cacheFilename;
+            include SRC_ROOT . $cacheFilename;
 
             return true;
         }
@@ -330,7 +330,7 @@ class TAutoloader extends TStaticObject
         $viewName = lcfirst($viewName);
         $include = null;
 //            $modelClass = ($include = TAutoloader::includeModelByName($viewName)) ? $include['type'] : DEFALT_MODEL;
-//            include SITE_ROOT . $include['file'];
+//            include SRC_ROOT . $include['file'];
 //            $model = new $modelClass();
 
           
@@ -342,7 +342,7 @@ class TAutoloader extends TStaticObject
         $view->setNames();
         if ($info !== null) {
             $include = self::_includeInnerClass($viewName, $info);
-            $view->setCacheFilename(SITE_ROOT . $cacheFilename);
+            $view->setCacheFilename(SRC_ROOT . $cacheFilename);
         } else {
             $include = self::includeClass($view->getControllerFileName(), RETURN_CODE);
         }
@@ -352,9 +352,9 @@ class TAutoloader extends TStaticObject
         $view->parse();
 
         self::getLogger()->debug('CACHE FILE NAME OF THE PARSED VIEW: ' . $view->getCacheFileName());
-        self::getLogger()->debug('ROOT CACHE FILE NAME OF THE PARSED VIEW: ' . SITE_ROOT . $cacheFilename);
+        self::getLogger()->debug('ROOT CACHE FILE NAME OF THE PARSED VIEW: ' . SRC_ROOT . $cacheFilename);
 
-        include SITE_ROOT . $cacheFilename;
+        include SRC_ROOT . $cacheFilename;
 
         return true;
     }
@@ -373,7 +373,7 @@ class TAutoloader extends TStaticObject
         include $cacheFilename;
 
         $classText = str_replace("\r", '', $classText);
-        $classText = str_replace("\n", '', $classText);
+        // $classText = str_replace("\n", '', $classText);
 
         $start = strpos($classText, 'namespace');
         $namespace = '';
@@ -381,10 +381,20 @@ class TAutoloader extends TStaticObject
             $start += 10;
             $end = strpos($classText, ';', $start);
             $namespace = substr($classText, $start, $end - $start);
-            $className = $namespace . '\\' . $parent->getClassName();
+            // $className = $namespace . '\\' . $parent->getClassName();
         }
+
+        $start = strpos($classText, 'class');
+        $className = '';
+        if ($start > 0) {
+            $start += 6;
+            $end = strpos($classText, ' ', $start);
+            $className = substr($classText, $start, $end - $start);
+        }
+        $fqClassName = $namespace . '\\' . $className;
+
         //$className = $include['type'];
-        $class = new $className($parent);
+        $class = new $fqClassName($parent);
         
         $class->perform();
 

--- a/src/phink/core/constants.php
+++ b/src/phink/core/constants.php
@@ -54,12 +54,13 @@ if (APP_IS_WEB) {
     define('HTTP_PROTOCOL', $scheme);
 
     if (substr(DOCUMENT_ROOT, -4) === 'web/') {
-        define('SITE_ROOT', substr(DOCUMENT_ROOT, 0, -4));
+        define('SRC_ROOT', substr(DOCUMENT_ROOT, 0, -4));
     } else {
-        define('SITE_ROOT', DOCUMENT_ROOT);
+        define('SRC_ROOT', DOCUMENT_ROOT);
     }
+    define('SITE_ROOT', substr(SRC_ROOT, 0, -4));
 
-    $appname = pathinfo(SITE_ROOT, PATHINFO_FILENAME);
+    $appname = pathinfo(SRC_ROOT, PATHINFO_FILENAME);
     define('APP_NAME', $appname);
 
     define('PHINK_VENDOR', 'vendor' . DIRECTORY_SEPARATOR . 'phink' . DIRECTORY_SEPARATOR . 'phink' . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'phink' . DIRECTORY_SEPARATOR);
@@ -67,7 +68,7 @@ if (APP_IS_WEB) {
 
     define('APP_DIR', 'app');
     
-    define('APP_ROOT', SITE_ROOT . APP_DIR . DIRECTORY_SEPARATOR);
+    define('APP_ROOT', SRC_ROOT . APP_DIR . DIRECTORY_SEPARATOR);
     define('CONTROLLER_ROOT', APP_ROOT . 'controllers' . DIRECTORY_SEPARATOR);
     define('MODEL_ROOT', APP_ROOT . 'models' . DIRECTORY_SEPARATOR);
     define('REST_ROOT', APP_ROOT . 'rest' . DIRECTORY_SEPARATOR);
@@ -75,13 +76,14 @@ if (APP_IS_WEB) {
     define('BUSINESS_ROOT', APP_ROOT . 'business' . DIRECTORY_SEPARATOR);
 
     define('REL_RUNTIME_DIR', 'runtime' . DIRECTORY_SEPARATOR);
-    define('RUNTIME_DIR', SITE_ROOT . REL_RUNTIME_DIR);
+    define('RUNTIME_DIR', SRC_ROOT . REL_RUNTIME_DIR);
     define('REL_RUNTIME_JS_DIR', 'js' . DIRECTORY_SEPARATOR . 'runtime' . DIRECTORY_SEPARATOR);
     define('REL_RUNTIME_CSS_DIR', 'css' . DIRECTORY_SEPARATOR . 'runtime' . DIRECTORY_SEPARATOR);
     define('RUNTIME_JS_DIR', DOCUMENT_ROOT . REL_RUNTIME_JS_DIR);
-    define('CACHE_DIR', SITE_ROOT . 'cache' . DIRECTORY_SEPARATOR);
+    define('RUNTIME_CSS_DIR', DOCUMENT_ROOT . REL_RUNTIME_CSS_DIR);
+    define('CACHE_DIR', SRC_ROOT . 'cache' . DIRECTORY_SEPARATOR);
     
-    define('LOG_PATH', SITE_ROOT . 'logs' . DIRECTORY_SEPARATOR);
+    define('LOG_PATH', SRC_ROOT . 'logs' . DIRECTORY_SEPARATOR);
     
     define('PAGE_NUMBER', 'pagen');
     define('PAGE_COUNT', 'pagec');
@@ -96,7 +98,7 @@ if (APP_IS_WEB) {
     define('LOGIN_PAGE', '/' . LOGIN_VIEW . '.html');
     define('MASTER_PAGE', '/' . MASTER_VIEW . '.html');
     define('HOME_PAGE', '/' . HOME_VIEW . '.html');
-    define('APP_DATA', SITE_ROOT . 'data' . DIRECTORY_SEPARATOR);
+    define('APP_DATA', SRC_ROOT . 'data' . DIRECTORY_SEPARATOR);
     define('APP_BUSINESS', APP_ROOT . 'business' . DIRECTORY_SEPARATOR);
     define('STARTER_FILE', 'starter.php');
     define('HTTP_USER_AGENT', $_SERVER['HTTP_USER_AGENT']);

--- a/src/phink/core/custom_application.php
+++ b/src/phink/core/custom_application.php
@@ -163,7 +163,7 @@ abstract class TCustomApplication extends TObject
     {
     }
 
-    protected function clearLogs() : string
+    public function clearLogs() : string
     {
         $result = '';
         try {
@@ -191,10 +191,10 @@ abstract class TCustomApplication extends TObject
     {
         try {
             $ini = null;
-            if (!file_exists(SITE_ROOT . 'config/app.ini')) {
+            if (!file_exists(SRC_ROOT . 'config/app.ini')) {
                 return;
             }
-            $ini = parse_ini_file(SITE_ROOT  . 'config/app.ini');
+            $ini = parse_ini_file(SRC_ROOT  . 'config/app.ini');
             $data = isset($ini['data']) ?? $ini['data'];
 
             self::getLogger()->dump('INI_DATA:', $ini);

--- a/src/phink/core/custom_application.php
+++ b/src/phink/core/custom_application.php
@@ -145,10 +145,36 @@ abstract class TCustomApplication extends TObject
                 }
             }
         );
+
+        $this->setCommand(
+            'rlog',
+            '',
+            'All logs and temporary files cleared',
+            function (callable $callback = null) {
+                $data = $this->clearLogs();
+                if ($callback !== null) {
+                    \call_user_func($callback, $data);
+                }
+            }
+        );
     }
     
     protected function displayConstants() : array
     {
+    }
+
+    protected function clearLogs() : string
+    {
+        $result = '';
+        try {
+            self::getLogger()->clearAll();
+            $result = 'All logs and temporary files cleared';
+        } catch (\Throwable $ex) {
+            self::writeException($ex);
+
+            $result = 'Impossible to clear logs';
+        }
+        return $result;
     }
 
     protected function getDebugLog() : string

--- a/src/phink/core/object.php
+++ b/src/phink/core/object.php
@@ -129,6 +129,7 @@ class TObject extends TStaticObject
 
     public function invoke($method, $params = array())
     {
+        $result = null;
         $values = array_values($params);
         
         if(count($values) > 0) {
@@ -136,12 +137,14 @@ class TObject extends TStaticObject
             self::$logger->debug(__METHOD__ . '::INVOKE_ACTION::' . $method  . '(' . $args . ')');
 //            include 'data://text/plain;base64,' . base64_encode('<?php $this->' . $method  . '(' . $args . ')');
             $ref = new \ReflectionMethod($this->getFQClassName(), $method);
-            $ref->invokeArgs($this, $values);
+            $result = $ref->invokeArgs($this, $values);
         } else {
             self::$logger->debug(__METHOD__ . '::INVOKE_ACTION::' . $method  . '()');
 //            $ref->invoke($this);
-            $this->$method();
-        }        
+            $result = $this->$method();
+        }
+
+        return $result;
     }
     
     public function getParent()

--- a/src/phink/core/registry.php
+++ b/src/phink/core/registry.php
@@ -48,6 +48,14 @@ class TRegistry extends TStaticObject
                 'canRender' => true,
                 'isAutoloaded' => true
             )
+            , 'TConsolew' => array(
+                'alias' => 'console',
+                'path' => '@' . DIRECTORY_SEPARATOR . 'web' . DIRECTORY_SEPARATOR . 'ui' . DIRECTORY_SEPARATOR . 'widget' . DIRECTORY_SEPARATOR . 'console' . DIRECTORY_SEPARATOR,
+                'namespace' => ROOT_NAMESPACE . '\Web\UI\Widget\Consolew',
+                'hasTemplate' => true,
+                'canRender' => true,
+                'isAutoloaded' => false
+            )
             , 'TPager' => array(
                 'alias' => 'pager',
                 'path' => DIRECTORY_SEPARATOR . 'web' . DIRECTORY_SEPARATOR . 'ui' . DIRECTORY_SEPARATOR . 'widget' . DIRECTORY_SEPARATOR . 'pager' . DIRECTORY_SEPARATOR,

--- a/src/phink/core/router.php
+++ b/src/phink/core/router.php
@@ -141,12 +141,14 @@ class TRouter extends TObject implements \Phink\Web\IWebObject
             $routesArray = [];
             $routesArray['web'] = [];
             $routesArray['web']['get'] = [];
+            $routesArray['web']['post'] = [];
         }
 
         $routesArray['web']['get']["^/console$"] = "@/web/ui/widget/console/console.phtml";
         $routesArray['web']['get']["^/console/$"] = "@/web/ui/widget/console/console.phtml?console=help";
         $routesArray['web']['get']["^/console/([a-z-]+)$"] = "@/web/ui/widget/console/console.phtml?console=$1";
         $routesArray['web']['get']["^/console/([a-z-]+)/([a-z-]+)$"] = "@/web/ui/widget/console/console.phtml?console=$1&arg=$2";
+        $routesArray['web']['post']["^/rlog$"] = "@/web/ui/widget/console/consolew.phtml";
 
         foreach ($routesArray as $key=>$value) {
             \Phink\Core\TRegistry::write('routes', $key, $value);

--- a/src/phink/css/css_builder.php
+++ b/src/phink/css/css_builder.php
@@ -77,7 +77,7 @@ class CssBuilder {
 //        $vendor = implode(DIRECTORY_SEPARATOR, $path) . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR;
         
 
-        $srcdir = SITE_ROOT . 'vendor' . DIRECTORY_SEPARATOR . 'components' . DIRECTORY_SEPARATOR;
+        $srcdir = SRC_ROOT . 'vendor' . DIRECTORY_SEPARATOR . 'components' . DIRECTORY_SEPARATOR;
 
 
         //$srcdir =  dirname(__FILE__) . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..'  . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'javascript' . DIRECTORY_SEPARATOR . 'thirdparty' . DIRECTORY_SEPARATOR . 'css' . DIRECTORY_SEPARATOR;

--- a/src/phink/data/data_access.php
+++ b/src/phink/data/data_access.php
@@ -31,7 +31,7 @@ class TDataAccess
     public static function getCryptoDB()
     {
 
-        $databaseName = \Phink\Utils\TFileUtils::filePath(SITE_ROOT . 'data/crypto.db');
+        $databaseName = \Phink\Utils\TFileUtils::filePath(SRC_ROOT . 'data/crypto.db');
 
         $sqlConfig = new TPdoConfiguration(TServerType::SQLITE, $databaseName);
         $connection = new TPdoConnection($sqlConfig);

--- a/src/phink/js/js_builder.php
+++ b/src/phink/js/js_builder.php
@@ -33,7 +33,7 @@ class JsBuilder {
         }
         $vendor = implode(DIRECTORY_SEPARATOR, $path) . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR;
         
-        $srcdir = SITE_ROOT . 'vendor' . DIRECTORY_SEPARATOR . 'components' . DIRECTORY_SEPARATOR;
+        $srcdir = SRC_ROOT . 'vendor' . DIRECTORY_SEPARATOR . 'components' . DIRECTORY_SEPARATOR;
         
         $js_content = '';
 
@@ -64,7 +64,7 @@ class JsBuilder {
         file_put_contents($js_filename, $js_content);
 
         // $srcdir = dirname(__FILE__) . DIRECTORY_SEPARATOR . 'bower_components' . DIRECTORY_SEPARATOR . 'phinkjs' . DIRECTORY_SEPARATOR . 'client' . DIRECTORY_SEPARATOR;
-        $srcdir = SITE_ROOT . 'web' . DIRECTORY_SEPARATOR . 'bower_components' . DIRECTORY_SEPARATOR . 'phinkjs' . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'client' . DIRECTORY_SEPARATOR;
+        $srcdir = SRC_ROOT . 'web' . DIRECTORY_SEPARATOR . 'bower_components' . DIRECTORY_SEPARATOR . 'phinkjs' . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'client' . DIRECTORY_SEPARATOR;
 
         $js_filename = DOCUMENT_ROOT . 'phink.js';
 

--- a/src/phink/log/log.php
+++ b/src/phink/log/log.php
@@ -85,4 +85,15 @@ class TLog
         }
         return \file_get_contents(DOCUMENT_ROOT . 'php_error_log');
     }
+
+    public function clearAll() : void
+    {
+        if (file_exists(DEBUG_LOG)) {
+            unlink(DEBUG_LOG);
+        }
+        if (file_exists(DOCUMENT_ROOT . 'php_error_log')) {
+            unlink(DOCUMENT_ROOT . 'php_error_log');
+        }
+
+    }
 }

--- a/src/phink/log/log.php
+++ b/src/phink/log/log.php
@@ -62,8 +62,8 @@ class TLog
         }
         $handle = fopen($filepath, 'a');
 
-        if (SITE_ROOT) {
-            $filename = substr($filename, strlen(SITE_ROOT));
+        if (SRC_ROOT) {
+            $filename = substr($filename, strlen(SRC_ROOT));
         }
         $message = date('Y-m-d h:i:s') . ((isset($filename)) ? ":$filename" : '') . ((isset($line)) ? ":$line" : '') . " : $message" . PHP_EOL;
         fwrite($handle, $message . PHP_EOL);

--- a/src/phink/mvc/action_info.php
+++ b/src/phink/mvc/action_info.php
@@ -1,0 +1,64 @@
+<?php
+/*
+ * Copyright (C) 2016 David Blanchard
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace Phink\MVC;
+
+use Phink\Web\IHttpTransport;
+use Phink\Web\TRequest;
+use Phink\Web\TResponse;
+use Phink\Core\TObject;
+
+class TActionInfo extends TObject implements IHttpTransport
+{
+
+    use \Phink\Web\THttpTransport;
+
+    protected $data = [];
+
+    public function __construct(IHttpTransport $parent)
+    {
+        parent::__construct($parent);
+    
+        // $this->application = $parent->getApplication();
+        // $this->commands = $this->application->getCommands();
+        $this->authentication = $parent->getAuthentication();
+        $this->request = $parent->getRequest();
+        $this->response = $parent->getResponse();
+        // $this->parameters = $parent->getParameters();
+    // $this->path = $this->getPath();
+
+    // $this->cloneNamesFrom($parent);
+    }
+
+    public static function set(IHttpTransport $parent, string $key, $value) : TActionInfo
+    {
+        $action = new TActionInfo($parent);
+        $action->setData($key, $value);
+
+        return $action;
+    }
+
+    public function setData(string $key, $value): void
+    {
+        $this->data[$key] = $value;
+    }
+
+    public function getData() : array
+    {
+        return $this->data;
+    }
+}

--- a/src/phink/mvc/custom_controller.php
+++ b/src/phink/mvc/custom_controller.php
@@ -20,6 +20,7 @@ namespace Phink\MVC;
 
 use Phink\Web\IWebObject;
 use Phink\Web\UI\TCustomControl;
+use TActionInfo;
 
 abstract class TCustomController extends TCustomControl
 {
@@ -151,7 +152,10 @@ abstract class TCustomController extends TCustomControl
                 // $this->renderCreations();
             
                 $params = $this->validate($actionName);
-                $this->invoke($actionName, $params);
+                $actionInfo = $this->invoke($actionName, $params);
+                if($actionInfo instanceof TActionInfo) {
+                    $this->response->setData($actionInfo->getData());
+                }
 
                 $this->beforeBinding();
                 // $this->renderDeclarations();

--- a/src/phink/mvc/custom_controller.php
+++ b/src/phink/mvc/custom_controller.php
@@ -198,10 +198,10 @@ abstract class TCustomController extends TCustomControl
         }
 */        
         self::$logger->debug(__METHOD__ . '::1::' . $this->getJsControllerFileName());
-        if(file_exists(SITE_ROOT . $this->getJsControllerFileName())) {
+        if(file_exists(SRC_ROOT . $this->getJsControllerFileName())) {
             self::$logger->debug(__METHOD__ . '::2::' . $this->getJsControllerFileName());
             $cacheJsFilename = \Phink\TAutoloader::cacheJsFilenameFromView($this->viewName);
-            copy(SITE_ROOT . $this->getJsControllerFileName(), DOCUMENT_ROOT . $cacheJsFilename);
+            copy(SRC_ROOT . $this->getJsControllerFileName(), DOCUMENT_ROOT . $cacheJsFilename);
             $this->response->addScript($cacheJsFilename);
         }        
     }

--- a/src/phink/mvc/custom_controller.php
+++ b/src/phink/mvc/custom_controller.php
@@ -82,8 +82,10 @@ abstract class TCustomController extends TCustomControl
     public function parse()
     {
         $this->cacheFileName = $this->view->getCacheFileName();
+        self::$logger->debug('CACHE FILE NAME IF EXISTS : ' . $this->cacheFileName, __FILE__, __LINE__);
 
         $isAlreadyParsed = file_exists($this->getCacheFileName());
+        self::$logger->debug('CACHED FILE EXISTS : ' . $isAlreadyParsed ? 'TRUE' : 'FALSE', __FILE__, __LINE__);
 
         if(!$isAlreadyParsed) {
             $this->_type = $this->view->parse();

--- a/src/phink/mvc/custom_view.php
+++ b/src/phink/mvc/custom_view.php
@@ -50,6 +50,7 @@ abstract class TCustomView extends TCustomControl
     {
         $this->setParent($parent);
         $this->path = $parent->getPath();
+        $this->application = $parent->getApplication();
         
         //$this->redis = new Client($this->context->getRedis());
     }
@@ -99,7 +100,8 @@ abstract class TCustomView extends TCustomControl
 
             $this->viewHtml = file_get_contents(SITE_ROOT . $this->viewFileName);
         } elseif (file_exists($this->getPath())) {
-            self::$logger->debug('PARSE PHINK VIEW : ' . $this->getPath(), __FILE__, __LINE__);
+            $path = str_replace("@/", PHINK_VENDOR, $this->getPath());
+            self::$logger->debug('PARSE PHINK VIEW : ' . $path, __FILE__, __LINE__);
 
             $this->viewHtml = file_get_contents($this->getPath());
         } else {

--- a/src/phink/mvc/custom_view.php
+++ b/src/phink/mvc/custom_view.php
@@ -95,20 +95,32 @@ abstract class TCustomView extends TCustomControl
 
         // $this->viewHtml = $this->redis->mget($templateName);
         // $this->viewHtml = $this->viewHtml[0];
-        if (file_exists(SITE_ROOT . $this->viewFileName)) {
-            self::$logger->debug('PARSE SITE ROOT FILE : ' . $this->viewFileName, __FILE__, __LINE__);
+        if (file_exists(SRC_ROOT . $this->viewFileName) && !empty($this->viewFileName)) {
+            self::$logger->debug('PARSE SRC ROOT FILE : ' . $this->viewFileName, __FILE__, __LINE__);
 
+            $this->viewHtml = file_get_contents(SRC_ROOT . $this->viewFileName);
+        }
+        if (file_exists(SITE_ROOT . $this->viewFileName) && !empty($this->viewFileName)) {
+            self::$logger->debug('PARSE SITE ROOT FILE : ' . $this->viewFileName, __FILE__, __LINE__);
+    
             $this->viewHtml = file_get_contents(SITE_ROOT . $this->viewFileName);
-        } elseif (file_exists($this->getPath())) {
-            $path = str_replace("@/", PHINK_VENDOR, $this->getPath());
+        }
+        if (file_exists(SITE_ROOT . $this->getPath()) && !empty($this->getPath())) {
+            $path = $this->getPath();
+            if ($path[0] == '@') {
+                $path = str_replace("@" . DIRECTORY_SEPARATOR, SITE_ROOT, $this->getPath());
+            } else {
+                $path = SITE_ROOT . $this->getPath();
+            }
             self::$logger->debug('PARSE PHINK VIEW : ' . $path, __FILE__, __LINE__);
 
-            $this->viewHtml = file_get_contents($this->getPath());
-        } else {
-            self::$logger->debug('PARSE PHINK PLUGIN : ' . $this->getPath(), __FILE__, __LINE__);
+            $this->viewHtml = file_get_contents($path);
+        } 
+        // else {
+        //     self::$logger->debug('PARSE PHINK PLUGIN : ' . $this->getPath(), __FILE__, __LINE__);
 
-            $this->viewHtml = file_get_contents($this->viewFileName, FILE_USE_INCLUDE_PATH);
-        }
+        //     $this->viewHtml = file_get_contents(SITE_ROOT . $this->viewFileName, FILE_USE_INCLUDE_PATH);
+        // }
         
         // $this->redis->mset($templateName, $this->viewHtml);
         //self::$logger->debug('HTML VIEW : [' . substr($this->viewHtml, 0, (strlen($this->viewHtml) > 25) ? 25 : strlen($this->viewHtml)) . '...]');

--- a/src/phink/phink_library.php
+++ b/src/phink/phink_library.php
@@ -59,6 +59,7 @@ class PhinkLibrary {
             'utils/file_utils.php',
             'crypto/crypto.php',
             'auth/authentication.php',
+            'mvc/action_info.php',
             'data/data_access.php',
             'data/server_type.php',
             'configuration/configurable.php',

--- a/src/phink/rest/rest_router.php
+++ b/src/phink/rest/rest_router.php
@@ -49,9 +49,9 @@ class TRestRouter extends \Phink\Core\TRouter
      
         $this->className = 'app' . DIRECTORY_SEPARATOR . 'rest' . DIRECTORY_SEPARATOR . $className . CLASS_EXTENSION;
         
-        // $this->getLogger()->debug('REST CONTROLLER: ' . SITE_ROOT . $this->className);
+        // $this->getLogger()->debug('REST CONTROLLER: ' . SRC_ROOT . $this->className);
         
-        return file_exists(SITE_ROOT . $this->className);
+        return file_exists(SRC_ROOT . $this->className);
     }
 
     public function dispatch()
@@ -60,12 +60,12 @@ class TRestRouter extends \Phink\Core\TRouter
         $method = REQUEST_METHOD;
 
         $model = str_replace('rest', 'models', $this->className);
-        if(file_exists(SITE_ROOT . $model)) {
-            include SITE_ROOT . $model;
+        if(file_exists(SRC_ROOT . $model)) {
+            include SRC_ROOT . $model;
         }
         
         $include = \Phink\TAutoloader::includeClass($this->className, INCLUDE_FILE);
-        include SITE_ROOT . $include['file'];
+        include SRC_ROOT . $include['file'];
         $fqObject = $include['type'];
         
         $instance = new $fqObject($this);

--- a/src/phink/ui/console_application.php
+++ b/src/phink/ui/console_application.php
@@ -71,26 +71,26 @@ class TConsoleApplication extends \Phink\Core\TCustomApplication
         $this->appName = array_pop($path);
         define('APP_NAME', $this->appName);
         
-        define('SITE_ROOT', $siteDir . DIRECTORY_SEPARATOR);
+        define('SRC_ROOT', $siteDir . DIRECTORY_SEPARATOR);
         define('SCRIPT_ROOT', $scriptDir);
 
         if (APP_NAME == 'egg') {
-            define('PHINK_ROOT', SITE_ROOT . 'phink' . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'phink' . DIRECTORY_SEPARATOR);
-            define('PHINK_ROOT', SITE_ROOT . 'phink' . DIRECTORY_SEPARATOR . 'phink' . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'phink' . DIRECTORY_SEPARATOR);
+            define('PHINK_ROOT', SRC_ROOT . 'phink' . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'phink' . DIRECTORY_SEPARATOR);
+            define('PHINK_ROOT', SRC_ROOT . 'phink' . DIRECTORY_SEPARATOR . 'phink' . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'phink' . DIRECTORY_SEPARATOR);
         } else {
-            define('PHINK_ROOT', SITE_ROOT . 'vendor' . DIRECTORY_SEPARATOR . 'phink' . DIRECTORY_SEPARATOR . 'phink' . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'phink' . DIRECTORY_SEPARATOR);
+            define('PHINK_ROOT', SRC_ROOT . 'vendor' . DIRECTORY_SEPARATOR . 'phink' . DIRECTORY_SEPARATOR . 'phink' . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'phink' . DIRECTORY_SEPARATOR);
         }
 
-        define('APP_ROOT', SITE_ROOT . 'app' . DIRECTORY_SEPARATOR);
+        define('APP_ROOT', SRC_ROOT . 'app' . DIRECTORY_SEPARATOR);
         define('APP_SCRIPTS', APP_ROOT . 'scripts' . DIRECTORY_SEPARATOR);
-        define('APP_DATA', SITE_ROOT . 'data' . DIRECTORY_SEPARATOR);
+        define('APP_DATA', SRC_ROOT . 'data' . DIRECTORY_SEPARATOR);
         define('APP_BUSINESS', APP_ROOT . 'business' . DIRECTORY_SEPARATOR);
         define('CONTROLLER_ROOT', APP_ROOT . 'controllers' . DIRECTORY_SEPARATOR);
         define('BUSINESS_ROOT', APP_ROOT . 'business' . DIRECTORY_SEPARATOR);
         define('MODEL_ROOT', APP_ROOT . 'models' . DIRECTORY_SEPARATOR);
         define('REST_ROOT', APP_ROOT . 'rest' . DIRECTORY_SEPARATOR);
         define('VIEW_ROOT', APP_ROOT . 'views' . DIRECTORY_SEPARATOR);
-        define('CACHE_DIR', SITE_ROOT . 'cache' . DIRECTORY_SEPARATOR);
+        define('CACHE_DIR', SRC_ROOT . 'cache' . DIRECTORY_SEPARATOR);
 
         $useTransaction = $this->setCommand('useTransactions');
         $execution = $this->setCommand('executionMode');
@@ -225,7 +225,7 @@ class TConsoleApplication extends \Phink\Core\TCustomApplication
             $constants['ERROR_LOG'] = ERROR_LOG;
 
             if (APP_NAME !== 'egg') {
-                $constants['SITE_ROOT'] = SITE_ROOT;
+                $constants['SRC_ROOT'] = SRC_ROOT;
                 $constants['APP_ROOT'] = APP_ROOT;
                 $constants['APP_SCRIPTS'] = APP_SCRIPTS;
                 $constants['APP_BUSINESS'] = APP_BUSINESS;

--- a/src/phink/utils/file_utils.php
+++ b/src/phink/utils/file_utils.php
@@ -79,7 +79,7 @@ class TFileUtils
         debug($filename);
         $filename = self::filePath($filename);
         if(strpos($filename, DIRECTORY_SEPARATOR) == 0) {
-            $filename = SITE_ROOT . $filename;
+            $filename = SRC_ROOT . $filename;
             $filename = self::filePath($filename);
         }
         debug($filename);

--- a/src/phink/web/ui/code_generator.php
+++ b/src/phink/web/ui/code_generator.php
@@ -120,8 +120,8 @@ trait TCodeGenerator {
                     $jsCode = '';
                     if(file_exists(DOCUMENT_ROOT . $fullJsCachePath)) {
                         $view->getResponse()->addScript($fullJsCachePath);
-                    } else if(file_exists(SITE_ROOT . $fullJsClassPath)) {
-                        $jsCtrlCode = file_get_contents(SITE_ROOT . $fullJsClassPath) . PHP_EOL;
+                    } else if(file_exists(SRC_ROOT . $fullJsClassPath)) {
+                        $jsCtrlCode = file_get_contents(SRC_ROOT . $fullJsClassPath) . PHP_EOL;
                         file_put_contents(DOCUMENT_ROOT . $fullJsCachePath, $jsCtrlCode);
                         $view->getResponse()->addScript($fullJsCachePath);
                     }
@@ -242,6 +242,14 @@ trait TCodeGenerator {
         $scripts = '';
         $head = '';
 
+        if(file_exists(SRC_ROOT . $view->getJsControllerFileName()) && !strstr($view->getJsControllerFileName(), 'main.js') && $view->getType() == 'TView') {
+            $cacheJsFilename = \Phink\TAutoloader::cacheJsFilenameFromView($view->getViewName());
+            if(!file_exists(DOCUMENT_ROOT . $cacheJsFilename)) {
+                copy(SRC_ROOT . $this->getJsControllerFileName(), DOCUMENT_ROOT . $cacheJsFilename);
+            }
+            // \Phink\Utils\TFileUtils::webPath($view->getCssFileName())
+            $scripts = "<script src='" . ((HTTP_HOST !== SERVER_NAME) ? SERVER_HOST : SERVER_ROOT) . WEB_SEPARATOR . $cacheJsFilename . "'></script>" . PHP_EOL;        
+        }
         if(file_exists(SITE_ROOT . $view->getJsControllerFileName()) && !strstr($view->getJsControllerFileName(), 'main.js') && $view->getType() == 'TView') {
             $cacheJsFilename = \Phink\TAutoloader::cacheJsFilenameFromView($view->getViewName());
             if(!file_exists(DOCUMENT_ROOT . $cacheJsFilename)) {
@@ -250,7 +258,16 @@ trait TCodeGenerator {
             // \Phink\Utils\TFileUtils::webPath($view->getCssFileName())
             $scripts = "<script src='" . ((HTTP_HOST !== SERVER_NAME) ? SERVER_HOST : SERVER_ROOT) . WEB_SEPARATOR . $cacheJsFilename . "'></script>" . PHP_EOL;        
         }
-        
+
+        if(file_exists(SRC_ROOT . $view->getCssFileName()) && $view->getType() == 'TView') {
+            $cacheCssFilename = \Phink\TAutoloader::cacheCssFilenameFromView($view->getViewName());
+            if(!file_exists(DOCUMENT_ROOT . $cacheCssFilename)) {
+                copy(SRC_ROOT . $view->getCssFileName(), DOCUMENT_ROOT . $cacheCssFilename);
+            }
+            //\Phink\Utils\TFileUtils::webPath($view->getCssFileName()
+            // $scripts .= "<script>Phink.Web.Object.getCSS('" . ((HTTP_HOST !== SERVER_NAME) ? SERVER_HOST : SERVER_ROOT) . WEB_SEPARATOR . $cacheCssFilename . "');</script>" . PHP_EOL;
+            $head = "<link rel='stylesheet' href='" . ((HTTP_HOST !== SERVER_NAME) ? SERVER_HOST : SERVER_ROOT) . WEB_SEPARATOR . $cacheCssFilename . "' />" . PHP_EOL;
+        }
         if(file_exists(SITE_ROOT . $view->getCssFileName()) && $view->getType() == 'TView') {
             $cacheCssFilename = \Phink\TAutoloader::cacheCssFilenameFromView($view->getViewName());
             if(!file_exists(DOCUMENT_ROOT . $cacheCssFilename)) {
@@ -260,7 +277,7 @@ trait TCodeGenerator {
             // $scripts .= "<script>Phink.Web.Object.getCSS('" . ((HTTP_HOST !== SERVER_NAME) ? SERVER_HOST : SERVER_ROOT) . WEB_SEPARATOR . $cacheCssFilename . "');</script>" . PHP_EOL;
             $head = "<link rel='stylesheet' href='" . ((HTTP_HOST !== SERVER_NAME) ? SERVER_HOST : SERVER_ROOT) . WEB_SEPARATOR . $cacheCssFilename . "' />" . PHP_EOL;
         }
-        
+
         if($scripts !== '') {
             $scripts .= '</body>' . PHP_EOL;
             $viewHtml = str_replace('</body>', $scripts, $viewHtml);

--- a/src/phink/web/ui/control.php
+++ b/src/phink/web/ui/control.php
@@ -16,9 +16,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
  
- namespace Phink\Web\UI;
+namespace Phink\Web\UI;
 
 use Phink\Core\TObject;
+use Phink\MVC\TActionInfo;
 
 class TControl extends TCustomControl
 {
@@ -148,7 +149,10 @@ class TControl extends TCustomControl
                 $actionName = $this->actionName;
 
                 $params = $this->validate($actionName);
-                $this->invoke($actionName, $params);
+                $actionInfo = $this->invoke($actionName, $params);
+                if($actionInfo instanceof TActionInfo) {
+                    $this->response->setData($actionInfo->getData());
+                }
 
                 $this->beforeBinding();
                 $this->declareObjects();

--- a/src/phink/web/ui/control.php
+++ b/src/phink/web/ui/control.php
@@ -45,7 +45,7 @@ class TControl extends TCustomControl
         $this->viewName = lcfirst($this->className);
         
         $include = \Phink\TAutoloader::includeModelByName($this->viewName);
-        $model = SITE_ROOT . $include['file'];
+        $model = SRC_ROOT . $include['file'];
         if(file_exists($model)) {
             include $model;
             $modelClass = $include['type'];
@@ -111,10 +111,10 @@ class TControl extends TCustomControl
             $this->response->addScript($cachedJsController);
         }
 */        
-        if(file_exists(SITE_ROOT . $this->getJsControllerFileName())) {
+        if(file_exists(SRC_ROOT . $this->getJsControllerFileName())) {
             $cacheJsFilename = \Phink\TAutoloader::cacheJsFilenameFromView($this->viewName);
             if(!file_exists(DOCUMENT_ROOT . $cacheJsFilename)) {
-                copy(SITE_ROOT . $this->getJsControllerFileName(), DOCUMENT_ROOT . $cacheJsFilename);
+                copy(SRC_ROOT . $this->getJsControllerFileName(), DOCUMENT_ROOT . $cacheJsFilename);
             }
             $this->response->addScript($cacheJsFilename);
         }

--- a/src/phink/web/ui/html_control.php
+++ b/src/phink/web/ui/html_control.php
@@ -84,7 +84,7 @@ trait THtmlControl
         $this->content = $value;
         if(isset($this->content[0]) && $this->content[0] === '@') {
             $templateName = str_replace(PREHTML_EXTENSION, '', substr($this->content,1));
-            $templateName = SITE_ROOT . 'app' . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . $templateName . PREHTML_EXTENSION;
+            $templateName = SRC_ROOT . 'app' . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . $templateName . PREHTML_EXTENSION;
 
             if(file_exists($templateName)) {
                 $contents = file_get_contents($templateName, FILE_USE_INCLUDE_PATH);

--- a/src/phink/web/ui/html_pattern.php
+++ b/src/phink/web/ui/html_pattern.php
@@ -51,7 +51,7 @@ trait THtmlPattern {
     
     public function getPatternName()
     {
-        return strtolower(ROOT_NAMESPACE) . DIRECTORY_SEPARATOR . 'web' . DIRECTORY_SEPARATOR . 'ui' . DIRECTORY_SEPARATOR . 'html' . PATTERN_EXTENSION;
+        return 'web' . DIRECTORY_SEPARATOR . 'ui' . DIRECTORY_SEPARATOR . 'html' . PATTERN_EXTENSION;
     }
 
     private function _getElements()
@@ -69,7 +69,7 @@ trait THtmlPattern {
         $patternName = $this->getPatternName();
         
         //self::$logger->dump('PATTERN NAME', $patternName);
-        $contents = file_get_contents($patternName, FILE_USE_INCLUDE_PATH);
+        $contents = file_get_contents(PHINK_ROOT . $patternName, FILE_USE_INCLUDE_PATH);
         
         $doc = new \Phink\Xml\TXmlDocument($contents);
         $doc->matchAll();

--- a/src/phink/web/ui/widget/console/console.class.php
+++ b/src/phink/web/ui/widget/console/console.class.php
@@ -1,0 +1,16 @@
+<?php
+namespace Sol\Controllers;
+
+use Phink\MVC\TController;
+
+class Console extends TController
+{
+    protected $console0;
+    
+    public function clearLogs() : void
+    {
+        // self::getLogger()->clearAll();
+        $data = $this->getApplication()->clearLogs();
+        $this->getResponse()->setData($data);
+    }    
+}

--- a/src/phink/web/ui/widget/console/console.css
+++ b/src/phink/web/ui/widget/console/console.css
@@ -21,3 +21,17 @@
     color: darkblue;
     background-color: antiquewhite;
 }
+
+#basics {
+    float: left;
+    position: relative;
+}
+
+#themes {
+    float: right;
+    position: relative;
+}
+
+#logo {
+    clear: both;
+}

--- a/src/phink/web/ui/widget/console/console.js
+++ b/src/phink/web/ui/widget/console/console.js
@@ -1,32 +1,42 @@
-var console = null;
-var consoleHost = window.location.hostname;
+var con = null;
+var conHost = window.location.hostname;
 Phink.DOM.ready(function () {
 
-    console = Phink.Web.Application.create(consoleHost);
-    console.main = console.createView('main');
+    con = Phink.Web.Application.create(conHost);
+    con.main = con.createView('main');
 
-    var consoleMain = console.createController(console.main, 'console.main')
-    .actions({
-        themeIbmPc: function () {
-            document.querySelector('html').setAttribute('class', 'ibm-pc');
-        }
-        , themeAmstradCpc: function () {
-            document.querySelector('html').setAttribute('class', 'amstrad-cpc');
-        }
-        , themeSolaris: function () {
-            document.querySelector('html').setAttribute('class', 'solaris');
-        }
-    })
-    .onload(function () {
-        consoleMain = this;
-        document.querySelector('#ibm-pcTheme').onclick = function() {
-            consoleMain.themeIbmPc();
-        }
-        document.querySelector('#amstrad-cpcTheme').onclick = function() {
-            consoleMain.themeAmstradCpc();
-        }
-        document.querySelector('#solarisTheme').onclick = function() {
-            consoleMain.themeSolaris();
-        }
-    });
+    var conMain = con.createController(con.main, 'con.main')
+        .actions({
+            themeIbmPc: function () {
+                document.querySelector('html').setAttribute('class', 'ibm-pc');
+            }
+            , themeAmstradCpc: function () {
+                document.querySelector('html').setAttribute('class', 'amstrad-cpc');
+            }
+            , themeSolaris: function () {
+                document.querySelector('html').setAttribute('class', 'solaris');
+            }
+            , clearLogs: function () {
+                this.getJSON('rlog', {
+                    "action": 'clearLogs'
+                } , function (data) {
+                    document.querySelector("#result").innerHtml = data;
+                });
+            }
+        })
+        .onload(function () {
+            conMain = this;
+            document.querySelector('#ibm-pcTheme').onclick = function () {
+                conMain.themeIbmPc();
+            }
+            document.querySelector('#amstrad-cpcTheme').onclick = function () {
+                conMain.themeAmstradCpc();
+            }
+            document.querySelector('#solarisTheme').onclick = function () {
+                conMain.themeSolaris();
+            }
+            document.querySelector('#rlog').onclick = function () {
+                conMain.clearLogs();
+            }
+        });
 });

--- a/src/phink/web/ui/widget/console/console.js
+++ b/src/phink/web/ui/widget/console/console.js
@@ -20,8 +20,12 @@ Phink.DOM.ready(function () {
                 this.getJSON('rlog', {
                     "action": 'clearLogs'
                 } , function (data) {
-                    document.querySelector("#result").innerHtml = data;
+                    document.querySelector("#result").innerHTML = data.result;
                 });
+                // this.getPartialView('rlog', 'clearLogs', "#result", {} , function (data) {
+                //     document.querySelector("#result").innerHTML = data.result;
+                //     // console.log(data);
+                // });
             }
         })
         .onload(function () {

--- a/src/phink/web/ui/widget/console/console.phtml
+++ b/src/phink/web/ui/widget/console/console.phtml
@@ -9,7 +9,7 @@
     <meta name="author" content="">
 
     <!-- <link href="/css/_3rdparty.css" rel="stylesheet"> -->
-    <link href="https://fonts.googleapis.com/css?family=PT+Mono" rel="stylesheet">
+    <!-- <link href="https://fonts.googleapis.com/css?family=PT+Mono" rel="stylesheet"> -->
     <script type="text/javascript" 
             data-depends="/js/_3rdparty.js" 
             src="/phink.js">
@@ -17,13 +17,17 @@
 
 </head>
 <body >
-    <div>
+    <div id="basics">
+        Basics&nbsp; 
+        <button id="rlog" >Clear logs</button>
+    </div>
+    <div id="themes">
         Themes&nbsp; 
         <button id="ibm-pcTheme" >IBM-PC</button>
         <button id="amstrad-cpcTheme" >AMSTRAD CPC</button>
         <button id="solarisTheme" >Solaris</button>
     </div>
-    <h3>
+    <h3 id="logo">
         <pre>
  ____  _     _       _
 |  _ \| |__ (_)_ __ | | __
@@ -38,6 +42,8 @@
     <h3>
     Console
     </h3>
-    <phx:TConsoleWindow id="console0"  />
+    <phx:TConsolew id="console0"  />
+    <div id="result">
+    </div>
 </body>
 </html>

--- a/src/phink/web/ui/widget/console/console.phtml
+++ b/src/phink/web/ui/widget/console/console.phtml
@@ -42,8 +42,8 @@
     <h3>
     Console
     </h3>
-    <phx:TConsolew id="console0"  />
     <div id="result">
     </div>
+    <phx:TConsolew id="console0"  />
 </body>
 </html>

--- a/src/phink/web/ui/widget/console/consolew.class.php
+++ b/src/phink/web/ui/widget/console/consolew.class.php
@@ -5,6 +5,7 @@ namespace Phink\Web\UI\Widget\Consolew;
 //require_once 'phink/mvc/partial_controller.php';
 
 use Phink\MVC\TPartialController;
+use Phink\MVC\TActionInfo;
 
 /**
  * Description of dummy
@@ -70,11 +71,10 @@ class TConsolew extends TPartialController
         }
     }
 
-    public function clearLogs() : void
+    public function clearLogs() : TActionInfo
     {
-        // self::getLogger()->clearLogs();
-
         $data = $this->getApplication()->clearLogs();
-        $this->getResponse()->setData('result', $data);
+
+        return TActionInfo::set($this, 'result', $data);
     }
 }

--- a/src/phink/web/ui/widget/console/consolew.class.php
+++ b/src/phink/web/ui/widget/console/consolew.class.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Phink\Web\UI\Widget\Consolew;
+
+//require_once 'phink/mvc/partial_controller.php';
+
+use Phink\MVC\TPartialController;
+
+/**
+ * Description of dummy
+ *
+ * @author david
+ */
+
+
+class TConsolew extends TPartialController
+{
+    protected $text = "Unknown command";
+    protected $args = '';
+ 
+    public function afterBinding() :void
+    {
+        $cmd = isset($this->parameters['console']) ? $this->parameters['console'] : '';
+        $arg = isset($this->parameters['arg']) ? $this->parameters['arg'] : null;
+
+        $this->setArgs($this->parameters);
+
+        $this->commandRunner($cmd, function ($data) {
+            $this->setText($data);
+        }, $arg);
+    }
+
+    public function setArgs($value) : void
+    {
+        $this->args = $value;
+        if (is_array($value)) {
+            $this->args = print_r($value, true);
+        }
+    }
+
+    public function getArgs() : array
+    {
+        return $this->args;
+    }
+    
+    public function setText($value) : void
+    {
+        $this->text = $value;
+        if (is_array($value)) {
+            $this->text = print_r($value, true);
+        }
+    }
+    
+    public function getText() : string
+    {
+        return $this->text;
+    }
+
+    public function commandRunner(string $cmd, callable $callback, ...$args) : void
+    {
+        if (isset($this->commands[$cmd])) {
+            $cmd = $this->commands[$cmd];
+            $statement = $cmd['callback'];
+
+            if ($statement !== null && count($args) === 0) {
+                call_user_func($statement, $callback);
+            } elseif ($statement !== null && count($args) > 0) {
+                call_user_func($statement, $callback, $args);
+            }
+        }
+    }
+
+    public function clearLogs() : void
+    {
+        // self::getLogger()->clearLogs();
+
+        $data = $this->getApplication()->clearLogs();
+        $this->getResponse()->setData($data);
+    }
+}

--- a/src/phink/web/ui/widget/console/consolew.class.php
+++ b/src/phink/web/ui/widget/console/consolew.class.php
@@ -75,6 +75,6 @@ class TConsolew extends TPartialController
         // self::getLogger()->clearLogs();
 
         $data = $this->getApplication()->clearLogs();
-        $this->getResponse()->setData($data);
+        $this->getResponse()->setData('result', $data);
     }
 }

--- a/src/phink/web/ui/widget/console/consolew.phtml
+++ b/src/phink/web/ui/widget/console/consolew.phtml
@@ -1,0 +1,6 @@
+<pre>
+<phx:echo var="args" />
+</pre>
+<pre>
+<phx:echo var="text" />
+</pre>

--- a/src/phink/web/ui/widget/pager/pager.class.php
+++ b/src/phink/web/ui/widget/pager/pager.class.php
@@ -67,7 +67,7 @@ class TPager extends \Phink\MVC\TPartialController
     }
 
     public function getCacheFilename() {
-        return SITE_ROOT . REL_RUNTIME_DIR . str_replace(DIRECTORY_SEPARATOR, '_', $this->path . $this->for . 'pager' . CLASS_EXTENSION);
+        return SRC_ROOT . REL_RUNTIME_DIR . str_replace(DIRECTORY_SEPARATOR, '_', $this->path . $this->for . 'pager' . CLASS_EXTENSION);
     }
 
     public function init()

--- a/src/phink/web/web_application.php
+++ b/src/phink/web/web_application.php
@@ -115,7 +115,7 @@ class TWebApplication extends \Phink\Core\TCustomApplication implements IHttpTra
         $constants = [];
         $constants['DOCUMENT_ROOT'] = DOCUMENT_ROOT;
         $constants['HTTP_PROTOCOL'] = HTTP_PROTOCOL;
-        $constants['SITE_ROOT'] = SITE_ROOT;
+        $constants['SRC_ROOT'] = SRC_ROOT;
         $constants['PHINK_ROOT'] = PHINK_ROOT;
         $constants['APP_NAME'] = APP_NAME;
         $constants['APP_ROOT'] = APP_ROOT;
@@ -216,9 +216,11 @@ class TWebApplication extends \Phink\Core\TCustomApplication implements IHttpTra
 //        }
 
         $this->getLogger()->debug("TRANSLATED ROUTE::" . $router->getPath());
+        $this->getLogger()->debug("TRANSLATED SRC ROUTE::" . SRC_ROOT . $router->getPath());
+        $this->getLogger()->debug("TRANSLATED PHINK ROUTE::" . SITE_ROOT . $router->getPath());
    
         if ((is_string($token) 
-        || file_exists(SITE_ROOT . $router->getPath()))
+        || (file_exists(SRC_ROOT . $router->getPath()) || file_exists(SITE_ROOT . $router->getPath())))
             && $router->isFound()
         ) {
             // We renew the token

--- a/src/phink/web/web_application.php
+++ b/src/phink/web/web_application.php
@@ -254,16 +254,6 @@ class TWebApplication extends \Phink\Core\TCustomApplication implements IHttpTra
 
     public static function writeException(\Throwable $ex, $file = null, $line = null) : void
     {
-        $message = '';
-
-        if ($ex instanceof \ErrorException) {
-            $message .= 'Error severity: ' . $ex->getSeverity() . PHP_EOL;
-        }
-        $message .= 'Error code: ' . $ex->getCode() . PHP_EOL;
-        $message .= 'In ' . $ex->getFile() . ', line ' . $ex->getLine() . PHP_EOL;
-        $message .= 'With the message: ' . $ex->getMessage() . PHP_EOL;
-        $message .= 'Stack trace: ' . $ex->getTraceAsString() . PHP_EOL;
-            
-        print  "\e[41m\033[37m" . $message . "\e[0m\033[0m";
+        self::getLogger()->error($ex, $file, $line);
     }
 }

--- a/src/phink/web/web_object.php
+++ b/src/phink/web/web_object.php
@@ -299,9 +299,9 @@ trait TWebObject
                 // $this->viewName = \Phink\TAutoloader::classNameToFilename($this->className);
                 $this->viewName = \Phink\TAutoloader::classNameToFilename($this->className);
                 if($info->path[0] == '@') {
-                    $path = str_replace("@" . DIRECTORY_SEPARATOR, PHINK_ROOT, $info->path);
+                    $path = str_replace("@" . DIRECTORY_SEPARATOR, PHINK_VENDOR, $info->path);
                 } else {
-                    $path = PHINK_ROOT . $info->path; 
+                    $path = PHINK_VENDOR . $info->path; 
                 }
                 // $path = $info->path;
                 if ($info->hasTemplate) {

--- a/src/phink/web/web_object.php
+++ b/src/phink/web/web_object.php
@@ -296,14 +296,22 @@ trait TWebObject
         if (!file_exists($this->viewFileName)) {
             $info = TRegistry::classInfo($this->className);
             if ($info !== null) {
+                // $this->viewName = \Phink\TAutoloader::classNameToFilename($this->className);
                 $this->viewName = \Phink\TAutoloader::classNameToFilename($this->className);
+                if($info->path[0] == '@') {
+                    $path = str_replace("@" . DIRECTORY_SEPARATOR, PHINK_ROOT, $info->path);
+                } else {
+                    $path = PHINK_ROOT . $info->path; 
+                }
+                // $path = $info->path;
                 if ($info->hasTemplate) {
-                    $this->viewFileName = ROOT_PATH . $info->path . $this->viewName . PREHTML_EXTENSION;
+                    $this->viewFileName = $path . $this->viewName . PREHTML_EXTENSION;
                 } else {
                     $this->viewFileName = '';
                 }
-                $this->controllerFileName = ROOT_PATH . $info->path . $this->viewName . CLASS_EXTENSION;
-                $this->jsControllerFileName = ROOT_PATH . $info->path . $this->viewName . JS_EXTENSION;
+                $this->controllerFileName = $path . $this->viewName . CLASS_EXTENSION;
+                $this->jsControllerFileName = $path . $this->viewName . JS_EXTENSION;
+                $this->cssFileName = $path . $this->viewName . CSS_EXTENSION;
                 $this->className = $info->namespace . '\\' . $this->className;
             }
         }

--- a/src/phink/web/web_router.php
+++ b/src/phink/web/web_router.php
@@ -48,6 +48,8 @@ class TWebRouter extends \Phink\Core\TRouter
 
     public function translate()
     {
+        $isTranslated = false;
+
         $info = (object) \pathinfo($this->path);
         $this->viewName = $info->filename;
         $this->dirName = $info->dirname;
@@ -57,17 +59,26 @@ class TWebRouter extends \Phink\Core\TRouter
         $this->setNamespace();
         $this->setNames();
 
-        if (file_exists($this->getCacheFileName())) {
-            $this->_isCached = true;
-            return $this->_isCached;
-        } else {
-            return file_exists(SITE_ROOT . $this->getPath());
+        if(file_exists(SRC_ROOT . $this->getPath())) {
+            // $this->path = SRC_ROOT . $this->getPath();
+            $isTranslated = true;
         }
+
+        if(file_exists(SITE_ROOT . $this->getPath())) {
+            // $this->path = SITE_ROOT . $this->getPath();
+            $isTranslated = true;
+        }
+
+        $this->_isCached = file_exists($this->getCacheFileName());
+
+        return $this->_isCached || $isTranslated;
     }
 
     public function dispatch()
     {
         if ($this->_isCached) {
+            // $view = new \Phink\MVC\TView($this);
+            // $view->parse();
             TAutoloader::loadCachedFile($this);
 
             return true;
@@ -107,6 +118,7 @@ class TWebRouter extends \Phink\Core\TRouter
     public function includeController()
     {
         $result = false;
+            $this->getLogger()->debug("Ready to dispatch 2");
         
         $result = TAutoloader::includeClass($this->controllerFileName, RETURN_CODE);
         if (!$result) {
@@ -125,6 +137,8 @@ class TWebRouter extends \Phink\Core\TRouter
     public function includePrimaryController()
     {
         if ($this->getRequest()->isAJAX() && $this->request->isPartialView()) {
+            $this->getLogger()->debug("Ready to dispatch");
+
             $result = TAutoloader::includeDefaultController($this->namespace, $this->className);
             \Phink\Core\TRegistry::setCode($this->controllerFileName, $result['code']);
         } else {

--- a/src/phink/web/web_router.php
+++ b/src/phink/web/web_router.php
@@ -118,7 +118,6 @@ class TWebRouter extends \Phink\Core\TRouter
     public function includeController()
     {
         $result = false;
-            $this->getLogger()->debug("Ready to dispatch 2");
         
         $result = TAutoloader::includeClass($this->controllerFileName, RETURN_CODE);
         if (!$result) {
@@ -137,8 +136,6 @@ class TWebRouter extends \Phink\Core\TRouter
     public function includePrimaryController()
     {
         if ($this->getRequest()->isAJAX() && $this->request->isPartialView()) {
-            $this->getLogger()->debug("Ready to dispatch");
-
             $result = TAutoloader::includeDefaultController($this->namespace, $this->className);
             \Phink\Core\TRegistry::setCode($this->controllerFileName, $result['code']);
         } else {


### PR DESCRIPTION
The dependencies Inclusions are now called from the Vendor directory.
The autoload.php from the Vendor directory can be used but phink_library.php still works as a standalone solution to avoid loading dozens of useless files when it's not necessary.
The cache layout has been redesigned to accept AJAX calls on the framework inner templates (Console).
An experimental ActionInfo class has been added to store data and states for the response without referencing the response. It also allows to type hint methods used on AJAX/Web requests while other can be of type void.